### PR TITLE
Fix GPL option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The CVC4 formula supports the following optional arguments:
 - `--HEAD`: Builds the current master branch of CVC4
 - `--with-java-bindings`: installs the Java bindings for CVC4
 - `--with-readline`: installs optional Readline support for improved
-  text-editing support in interactive mode. Requires the `enable-gpl` option
-- `--enable-gpl`: Permit GPL dependences, if available
+  text-editing support in interactive mode. Requires the `with-gpl` option
+- `--with-gpl`: Permit GPL dependences, if available
 
 ## Using the Java bindings
 


### PR DESCRIPTION
Option `enable-gpl` is actually called `with-gpl`.