### PR TITLE
Test `--HEAD` using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,23 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every day at 1am
+    - cron: '0 1 * * *'
 
 jobs:
   build:
+    strategy:
+      matrix:
+        name: [latest-release, head]
+
+        include:
+          - name: latest-release
+
+          - name: head
+            config: --HEAD
+
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -16,7 +31,7 @@ jobs:
     - name: Audit
       run: brew audit --formula "${{ github.workspace }}/Formula/cvc4.rb"
     - name: Install
-      run: brew install cvc4/cvc4/cvc4 --verbose
+      run: brew install cvc4/cvc4/cvc4 --verbose ${{ matrix.config }}
     - name: Test
       run: |
         brew test cvc4


### PR DESCRIPTION
This commit adds another build that tests `--HEAD` using GitHub actions.
It also makes the job run every night at 1am.