### PR TITLE
Temporarily use auto-download

### DIFF
--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -39,14 +39,15 @@ class Cvc4 < Formula
     venv.pip_install resources
 
     args = ["--prefix=#{prefix}",
-            "--symfpu",
             "--cryptominisat",
             "--no-cadical"]
 
-    args << "--python3" unless build.head?
+    args << "--gpl" if allow_gpl?
     args << "--language-bindings=java" if build.with? "java-bindings"
     args << "--no-poly" if build.head?
-    args << "--gpl" if allow_gpl?
+    args << "--no-symfpu" if build.head?
+    args << "--python3" unless build.head?
+    args << "--symfpu" unless build.head?
 
     if build.with? "readline"
       gpl_dependency "readline"

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -39,15 +39,14 @@ class Cvc4 < Formula
     venv.pip_install resources
 
     args = ["--prefix=#{prefix}",
-            "--cryptominisat",
-            "--no-cadical"]
+            "--symfpu",
+            "--cryptominisat"]
 
-    args << "--gpl" if allow_gpl?
-    args << "--language-bindings=java" if build.with? "java-bindings"
-    args << "--no-poly" if build.head?
-    args << "--no-symfpu" if build.head?
+    # TODO: Replace with separate formulas
+    args << "--auto-download" if build.head?
     args << "--python3" unless build.head?
-    args << "--symfpu" unless build.head?
+    args << "--language-bindings=java" if build.with? "java-bindings"
+    args << "--gpl" if allow_gpl?
 
     if build.with? "readline"
       gpl_dependency "readline"

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -45,6 +45,7 @@ class Cvc4 < Formula
 
     args << "--python3" unless build.head?
     args << "--language-bindings=java" if build.with? "java-bindings"
+    args << "--no-poly" if build.head?
     args << "--gpl" if allow_gpl?
 
     if build.with? "readline"

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -40,7 +40,8 @@ class Cvc4 < Formula
 
     args = ["--prefix=#{prefix}",
             "--symfpu",
-            "--cryptominisat"]
+            "--cryptominisat",
+            "--no-cadical"]
 
     args << "--python3" unless build.head?
     args << "--language-bindings=java" if build.with? "java-bindings"


### PR DESCRIPTION
This commit turns on auto-download for `--HEAD` to make the formula work again. Eventually, we should break out the dependencies into different formulas.