### PR TITLE
Create symlink for `cvc4` when installing `--HEAD`

### DIFF
--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -58,11 +58,10 @@ class Cvc4 < Formula
       system "make", "install"
     end
 
-    bin.install_symlink "#{bin}/cvc5" => "#{bin}/cvc4" if build.head?
+    bin.install_symlink "#{bin}/cvc4" => "#{bin}/cvc5" if build.head?
   end
 
   test do
-    binary = "#{bin}/#{build.head? ? "cvc5" : "cvc4"}"
     (testpath/"simple.cvc").write <<~EOS
       x0, x1, x2, x3 : BOOLEAN;
       ASSERT x1 OR NOT x0;
@@ -72,7 +71,7 @@ class Cvc4 < Formula
       % EXPECT: entailed
       QUERY x2;
     EOS
-    result = shell_output "#{binary} #{testpath/"simple.cvc"}"
+    result = shell_output "#{bin}/cvc4 #{testpath/"simple.cvc"}"
     assert_match(/entailed/, result)
     (testpath/"simple.smt").write <<~EOS
       (set-option :produce-models true)
@@ -82,7 +81,7 @@ class Cvc4 < Formula
       (assert (not s_1))
       (check-sat)
     EOS
-    result = shell_output "#{binary} --lang smt #{testpath/"simple.smt"}"
+    result = shell_output "#{bin}/cvc4 --lang smt #{testpath/"simple.smt"}"
     assert_match(/unsat/, result)
   end
 

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -57,9 +57,12 @@ class Cvc4 < Formula
     chdir "build" do
       system "make", "install"
     end
+
+    ln_s "#{prefix}/cvc4", "#{prefix}/cvc5" if build.head
   end
 
   test do
+    binary = "#{bin}/#{build.head? "cvc5" : "cvc4"}"
     (testpath/"simple.cvc").write <<~EOS
       x0, x1, x2, x3 : BOOLEAN;
       ASSERT x1 OR NOT x0;
@@ -69,7 +72,7 @@ class Cvc4 < Formula
       % EXPECT: entailed
       QUERY x2;
     EOS
-    result = shell_output "#{bin}/cvc4 #{testpath/"simple.cvc"}"
+    result = shell_output "#{binary} #{testpath/"simple.cvc"}"
     assert_match(/entailed/, result)
     (testpath/"simple.smt").write <<~EOS
       (set-option :produce-models true)
@@ -79,7 +82,7 @@ class Cvc4 < Formula
       (assert (not s_1))
       (check-sat)
     EOS
-    result = shell_output "#{bin}/cvc4 --lang smt #{testpath/"simple.smt"}"
+    result = shell_output "#{binary} --lang smt #{testpath/"simple.smt"}"
     assert_match(/unsat/, result)
   end
 

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -62,7 +62,7 @@ class Cvc4 < Formula
   end
 
   test do
-    binary = "#{bin}/#{build.head? "cvc5" : "cvc4"}"
+    binary = "#{bin}/#{build.head? ? "cvc5" : "cvc4"}"
     (testpath/"simple.cvc").write <<~EOS
       x0, x1, x2, x3 : BOOLEAN;
       ASSERT x1 OR NOT x0;

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -58,7 +58,7 @@ class Cvc4 < Formula
       system "make", "install"
     end
 
-    bin.install_symlink "#{prefix}/cvc5" => "#{prefix}/cvc4"  if build.head
+    bin.install_symlink "#{prefix}/cvc5" => "#{prefix}/cvc4" if build.head
   end
 
   test do

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -58,7 +58,7 @@ class Cvc4 < Formula
       system "make", "install"
     end
 
-    ln_s "#{prefix}/cvc4", "#{prefix}/cvc5" if build.head
+    bin.install_symlink "#{prefix}/cvc5" => "#{prefix}/cvc4"  if build.head
   end
 
   test do

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -58,7 +58,7 @@ class Cvc4 < Formula
       system "make", "install"
     end
 
-    bin.install_symlink "#{prefix}/cvc5" => "#{prefix}/cvc4" if build.head?
+    bin.install_symlink "#{prefix}/bin/cvc5" => "#{prefix}/bin/cvc4" if build.head?
   end
 
   test do

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -58,7 +58,7 @@ class Cvc4 < Formula
       system "make", "install"
     end
 
-    bin.install_symlink "cvc4" => "cvc5" if build.head?
+    bin.install_symlink "cvc5" => "cvc4" if build.head?
   end
 
   test do

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -58,7 +58,7 @@ class Cvc4 < Formula
       system "make", "install"
     end
 
-    bin.install_symlink "#{prefix}/bin/cvc5" => "#{prefix}/bin/cvc4" if build.head?
+    bin.install_symlink "#{bin}/cvc5" => "#{bin}/cvc4" if build.head?
   end
 
   test do

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -58,7 +58,7 @@ class Cvc4 < Formula
       system "make", "install"
     end
 
-    bin.install_symlink "#{bin}/cvc4" => "#{bin}/cvc5" if build.head?
+    bin.install_symlink "cvc4" => "cvc5" if build.head?
   end
 
   test do

--- a/Formula/cvc4.rb
+++ b/Formula/cvc4.rb
@@ -58,7 +58,7 @@ class Cvc4 < Formula
       system "make", "install"
     end
 
-    bin.install_symlink "#{prefix}/cvc5" => "#{prefix}/cvc4" if build.head
+    bin.install_symlink "#{prefix}/cvc5" => "#{prefix}/cvc4" if build.head?
   end
 
   test do


### PR DESCRIPTION
In anticipation of the cvc5 release, the binary name has changed to `cvc5`. This commit introduces a `cvc4` symlink s.t. existing users of CVC4 can continue calling `cvc4` while cvc5 is not officially released yet.